### PR TITLE
Fix broken links to 1.22 connection demo repo in-app

### DIFF
--- a/1.22/st-experimental-connection/pages/05_🏂_Snowpark.py
+++ b/1.22/st-experimental-connection/pages/05_🏂_Snowpark.py
@@ -16,7 +16,7 @@ st.info("`SnowparkConnection` makes it easy to connect to Snowflake and Snowpark
 """
 A SnowparkConnection example is shown here, but won't work in the Cloud app since it needs local Snowflake credentials.
 To use it, you can:
-- Clone [this app](https://github.com/streamlit/release-demos/tree/master/1.22.0/st-experimental-connection) locally
+- Clone [this app](https://github.com/streamlit/release-demos/tree/master/1.22/st-experimental-connection) locally
 - Run `pip install "streamlit>=1.22" "snowflake-snowpark-python[pandas]"` or equivalent
 - Set up local credentials for your Snowflake account.
 """

--- a/1.22/st-experimental-connection/pages/07_🏗️_Build_your_own.py
+++ b/1.22/st-experimental-connection/pages/07_🏗️_Build_your_own.py
@@ -14,7 +14,7 @@ st.info("`ExperimentalBaseConnection` makes it easy to build, use and share your
 You can build your own Connection by extending the [built-in ExperimentalBaseConnection.](https://docs.streamlit.io/library/api-reference/connections/st.connections.experimentalbaseconnection)
 To demonstrate this, this app has a simple [DuckDB](https://duckdb.org/) Connection built in.
 You can view the connection source code
-[here](https://github.com/streamlit/release-demos/blob/master/1.22.0/st-experimental-connection/duckdb_connection/connection.py).
+[here](https://github.com/streamlit/release-demos/blob/master/1.22/st-experimental-connection/duckdb_connection/connection.py).
 """
 
 """
@@ -68,7 +68,7 @@ def query(self, query: str, ttl: int = 3600, **kwargs) -> pd.DataFrame:
 with st.expander("To show it's that easy, see the DuckDB code running here :rocket:"):
     """
     You can view the DuckDB connection source code
-    [here](https://github.com/streamlit/release-demos/blob/master/1.22.0/st-experimental-connection/duckdb_connection/connection.py).
+    [here](https://github.com/streamlit/release-demos/blob/master/1.22/st-experimental-connection/duckdb_connection/connection.py).
     """
 
     with st.echo():


### PR DESCRIPTION
Set a couple of links pre-merge in the demo and guessed the URLs incorrectly

- Two links to [duckdb connection](https://github.com/streamlit/release-demos/blob/master/1.22/st-experimental-connection/duckdb_connection/connection.py) in Build Your Own Connection section
- One link to whole repo in Snowpark section