### PR TITLE
[syntax error fixed] Update 92_Interactive_Layered_Crossfilter.py

### DIFF
--- a/1.16.0/demo_app_altair/pages/92_Interactive_Layered_Crossfilter.py
+++ b/1.16.0/demo_app_altair/pages/92_Interactive_Layered_Crossfilter.py
@@ -33,8 +33,7 @@ def get_chart_96623(use_container_width: bool):
     # blue highlights on the transformed data
     highlight = base.transform_filter(brush)
     
-    chart = # layer the two charts & repeat
-    alt.layer(
+    chart = alt.layer( # layer the two charts & repeat
         background,
         highlight,
         data=source


### PR DESCRIPTION
There was a simple syntax error in line 36 when I ran the online demo at <https://altair.streamlit.app/Interactive_Layered_Crossfilter>

File "/app/release-demos/1.16.0/demo_app_altair/pages/92_Interactive_Layered_Crossfilter.py", line 36
      chart = # layer the two charts & repeat
              ^
SyntaxError: invalid syntax